### PR TITLE
Update rte_ecowatt.html

### DIFF
--- a/core/template/dashboard/rte_ecowatt.html
+++ b/core/template/dashboard/rte_ecowatt.html
@@ -141,6 +141,7 @@
       series: [
         { name: '#date0dm#',
             colorByPoint: false,
+	    colorIndex: 999,
             innerSize: '#innerSizeAM#',
             data: [ #dataHour0HCpieAM# ]
         }
@@ -179,6 +180,7 @@
       series: [
         { name: '#date0dm#',
           colorByPoint: false,
+	  colorIndex: 999,
           innerSize: '#innerSizePM#',
           data: [ #dataHour0HCpiePM# ]
         },


### PR DESCRIPTION
Force la class "highcharts-color-" a 999 (highcharts-color-999) ainsi en thème Legacy, le core n'interagit plus sur l'attribut "fill" de la class css.